### PR TITLE
ignore tensorflow deprecation warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 init:
 	pip install -r requirements.txt
 
-TEST_ARGS = --doctest-modules --doctest-continue-on-failure --cov matchzoo/ --cov-report term-missing --cov-report html --cov-config .coveragerc matchzoo/ tests/
+TEST_ARGS = --doctest-modules --doctest-continue-on-failure --cov matchzoo/ --cov-report term-missing --cov-report html --cov-config .coveragerc matchzoo/ tests/ -W ignore::DeprecationWarning
 
 test:
 	pytest $(TEST_ARGS)


### PR DESCRIPTION
ignore warning in tensorflow (not fixed at the moment).  see [here](https://github.com/tensorflow/tensorflow/issues/16152)