### PR TITLE
Fix SNLI data loading index mismatch bug.

### DIFF
--- a/matchzoo/datasets/snli/load_data.py
+++ b/matchzoo/datasets/snli/load_data.py
@@ -83,5 +83,5 @@ def _read_data(path):
         'text_right': table['sentence2'],
         'label': table['gold_label']
     })
-    df.dropna(axis=0, how='any', inplace=True)
+    df = df.dropna(axis=0, how='any').reset_index(drop=True)
     return matchzoo.pack(df)


### PR DESCRIPTION
Cause: `dropna` creates index gaps in the data frame since some of the items are removed, but `pack` generates ids consecutively and some ids might fall in the index gaps. `reset_index` fills up the index gaps and fixes the bug.