### PR TITLE
seperate OOV with PAD in the vocabulary

### DIFF
--- a/matchzoo/embedding/embedding.py
+++ b/matchzoo/embedding/embedding.py
@@ -25,13 +25,13 @@ class Embedding(object):
     To load from a file:
         >>> embedding = mz.embedding.load_from_file(embed_path)
         >>> matrix = embedding.build_matrix(term_index)
-        >>> matrix.shape[0] == len(term_index) + 1
+        >>> matrix.shape[0] == len(term_index)
         True
 
     To build your own:
         >>> data = pd.DataFrame(data=[[0, 1], [2, 3]], index=['A', 'B'])
         >>> embedding = mz.Embedding(data)
-        >>> matrix = embedding.build_matrix({'A': 2, 'B': 1})
+        >>> matrix = embedding.build_matrix({'A': 2, 'B': 1, '_PAD': 0})
         >>> matrix.shape == (3, 2)
         True
 
@@ -70,7 +70,7 @@ class Embedding(object):
             `(-0.2, 0.2)`).
         :return: A matrix.
         """
-        input_dim = len(term_index) + 1
+        input_dim = len(term_index)
 
         matrix = np.empty((input_dim, self.output_dim))
         for index in np.ndindex(*matrix.shape):

--- a/matchzoo/models/mvlstm.py
+++ b/matchzoo/models/mvlstm.py
@@ -52,7 +52,7 @@ class MVLSTM(BaseModel):
         query, doc = self._make_inputs()
 
         # Embedding layer
-        embedding = self._make_embedding_layer()
+        embedding = self._make_embedding_layer(mask_zero=True)
         embed_query = embedding(query)
         embed_doc = embedding(doc)
 

--- a/matchzoo/preprocessors/basic_preprocessor.py
+++ b/matchzoo/preprocessors/basic_preprocessor.py
@@ -44,7 +44,7 @@ class BasicPreprocessor(BasePreprocessor):
         >>> preprocessor.context['input_shapes']
         [(10,), (20,)]
         >>> preprocessor.context['vocab_size']
-        225
+        226
         >>> processed_train_data = preprocessor.transform(train_data,
         ...                                               verbose=0)
         >>> type(processed_train_data)
@@ -105,7 +105,7 @@ class BasicPreprocessor(BasePreprocessor):
         vocab_unit = build_vocab_unit(data_pack, verbose=verbose)
         self._context['vocab_unit'] = vocab_unit
 
-        vocab_size = len(vocab_unit.state['term_index']) + 1
+        vocab_size = len(vocab_unit.state['term_index'])
         self._context['vocab_size'] = vocab_size
         self._context['embedding_input_dim'] = vocab_size
         self._context['input_shapes'] = [(self._fixed_length_left,),

--- a/matchzoo/preprocessors/cdssm_preprocessor.py
+++ b/matchzoo/preprocessors/cdssm_preprocessor.py
@@ -73,7 +73,7 @@ class CDSSMPreprocessor(BasePreprocessor):
         vocab_unit = build_vocab_unit(data_pack, verbose=verbose)
 
         self._context['vocab_unit'] = vocab_unit
-        vocab_size = len(vocab_unit.state['term_index']) + 1
+        vocab_size = len(vocab_unit.state['term_index'])
         self._context['input_shapes'] = [
             (self._fixed_length_left, vocab_size),
             (self._fixed_length_right, vocab_size)

--- a/matchzoo/preprocessors/dssm_preprocessor.py
+++ b/matchzoo/preprocessors/dssm_preprocessor.py
@@ -58,7 +58,7 @@ class DSSMPreprocessor(BasePreprocessor):
         vocab_unit = build_vocab_unit(data_pack, verbose=verbose)
 
         self._context['vocab_unit'] = vocab_unit
-        vocab_size = len(vocab_unit.state['term_index']) + 1
+        vocab_size = len(vocab_unit.state['term_index'])
         self._context['vocab_size'] = vocab_size
         self._context['embedding_input_dim'] = vocab_size
         self._context['input_shapes'] = [(vocab_size,), (vocab_size,)]

--- a/matchzoo/preprocessors/units/vocabulary.py
+++ b/matchzoo/preprocessors/units/vocabulary.py
@@ -9,16 +9,16 @@ class Vocabulary(StatefulUnit):
         >>> vocab = Vocabulary()
         >>> vocab.fit(['A', 'B', 'C', 'D', 'E'])
         >>> term_index = vocab.state['term_index']
-        >>> term_index  # doctest: +SKIP
-        {'E': 2, 'C': 3, 'D': 4, 'A': 5, 'B': 6}
+        >>> term_index
+        {'<PAD>': 0, '<OOV>': 1, 'D': 2, 'A': 3, 'B': 4, 'C': 5, 'E': 6}
         >>> index_term = vocab.state['index_term']
-        >>> index_term  # doctest: +SKIP
-        {2: 'C', 3: 'A', 4: 'E', 5: 'B', 6: 'D'}
+        >>> index_term
+        {0: '<PAD>', 1: '<OOV>', 2: 'D', 3: 'A', 4: 'B', 5: 'C', 6: 'E'}
 
         >>> term_index['out-of-vocabulary-term']
         1
         >>> index_term[0]
-        'PAD'
+        '<PAD>'
         >>> index_term[42]
         Traceback (most recent call last):
             ...
@@ -27,25 +27,13 @@ class Vocabulary(StatefulUnit):
         >>> c_index = term_index['C']
         >>> vocab.transform(['C', 'A', 'C']) == [c_index, a_index, c_index]
         True
-        >>> vocab.transform(['C', 'A', 'OOV']) == [c_index, a_index, 1]
+        >>> vocab.transform(['C', 'A', '<OOV>']) == [c_index, a_index, 1]
         True
         >>> indices = vocab.transform(list('ABCDDZZZ'))
         >>> ' '.join(vocab.state['index_term'][i] for i in indices)
-        'A B C D D OOV OOV OOV'
+        'A B C D D <OOV> <OOV> <OOV>'
 
     """
-
-    class IndexTerm(dict):
-        """Map index to term."""
-
-        def __missing__(self, key):
-            """Map out-of-vocabulary indices to empty string."""
-            if key == 1:
-                return 'OOV'
-            elif key == 0:
-                return 'PAD'
-            else:
-                raise KeyError(key)
 
     class TermIndex(dict):
         """Map term to index."""
@@ -57,11 +45,11 @@ class Vocabulary(StatefulUnit):
     def fit(self, tokens: list):
         """Build a :class:`TermIndex` and a :class:`IndexTerm`."""
         self._state['term_index'] = self.TermIndex()
-        self._state['index_term'] = self.IndexTerm()
-        self._state['term_index']['PAD'] = 0
-        self._state['term_index']['OOV'] = 1
-        self._state['index_term'][0] = 'PAD'
-        self._state['index_term'][1] = 'OOV'
+        self._state['index_term'] = dict()
+        self._state['term_index']['<PAD>'] = 0
+        self._state['term_index']['<OOV>'] = 1
+        self._state['index_term'][0] = '<PAD>'
+        self._state['index_term'][1] = '<OOV>'
         terms = set(tokens)
         for index, term in enumerate(terms):
             self._state['term_index'][term] = index + 2

--- a/matchzoo/preprocessors/units/vocabulary.py
+++ b/matchzoo/preprocessors/units/vocabulary.py
@@ -18,7 +18,7 @@ class Vocabulary(StatefulUnit):
         >>> term_index['out-of-vocabulary-term']
         1
         >>> index_term[0]
-        '_PAD'
+        'PAD'
         >>> index_term[42]
         Traceback (most recent call last):
             ...
@@ -43,7 +43,7 @@ class Vocabulary(StatefulUnit):
             if key == 1:
                 return 'OOV'
             elif key == 0:
-                return '_PAD'
+                return 'PAD'
             else:
                 raise KeyError(key)
 
@@ -58,9 +58,9 @@ class Vocabulary(StatefulUnit):
         """Build a :class:`TermIndex` and a :class:`IndexTerm`."""
         self._state['term_index'] = self.TermIndex()
         self._state['index_term'] = self.IndexTerm()
-        self._state['term_index']['_PAD'] = 0
+        self._state['term_index']['PAD'] = 0
         self._state['term_index']['OOV'] = 1
-        self._state['index_term'][0] = '_PAD'
+        self._state['index_term'][0] = 'PAD'
         self._state['index_term'][1] = 'OOV'
         terms = set(tokens)
         for index, term in enumerate(terms):

--- a/matchzoo/preprocessors/units/vocabulary.py
+++ b/matchzoo/preprocessors/units/vocabulary.py
@@ -5,20 +5,23 @@ class Vocabulary(StatefulUnit):
     """
     Vocabulary class.
 
+    :param pad_value: The string value for the padding position.
+    :param oov_value: The string value for the out-of-vocabulary terms.
+
     Examples:
-        >>> vocab = Vocabulary()
+        >>> vocab = Vocabulary(pad_value='[PAD]', oov_value='[OOV]')
         >>> vocab.fit(['A', 'B', 'C', 'D', 'E'])
         >>> term_index = vocab.state['term_index']
-        >>> term_index
-        {'<PAD>': 0, '<OOV>': 1, 'D': 2, 'A': 3, 'B': 4, 'C': 5, 'E': 6}
+        >>> term_index  # doctest: +SKIP
+        {'[PAD]': 0, '[OOV]': 1, 'D': 2, 'A': 3, 'B': 4, 'C': 5, 'E': 6}
         >>> index_term = vocab.state['index_term']
-        >>> index_term
-        {0: '<PAD>', 1: '<OOV>', 2: 'D', 3: 'A', 4: 'B', 5: 'C', 6: 'E'}
+        >>> index_term  # doctest: +SKIP
+        {0: '[PAD]', 1: '[OOV]', 2: 'D', 3: 'A', 4: 'B', 5: 'C', 6: 'E'}
 
         >>> term_index['out-of-vocabulary-term']
         1
         >>> index_term[0]
-        '<PAD>'
+        '[PAD]'
         >>> index_term[42]
         Traceback (most recent call last):
             ...
@@ -27,13 +30,21 @@ class Vocabulary(StatefulUnit):
         >>> c_index = term_index['C']
         >>> vocab.transform(['C', 'A', 'C']) == [c_index, a_index, c_index]
         True
-        >>> vocab.transform(['C', 'A', '<OOV>']) == [c_index, a_index, 1]
+        >>> vocab.transform(['C', 'A', '[OOV]']) == [c_index, a_index, 1]
         True
         >>> indices = vocab.transform(list('ABCDDZZZ'))
         >>> ' '.join(vocab.state['index_term'][i] for i in indices)
-        'A B C D D <OOV> <OOV> <OOV>'
+        'A B C D D [OOV] [OOV] [OOV]'
 
     """
+
+    def __init__(self, pad_value: str = '<PAD>', oov_value: str = '<OOV>'):
+        """Vocabulary unit initializer."""
+        self._pad = pad_value
+        self._oov = oov_value
+        self._state = {}
+        self._state['term_index'] = self.TermIndex()
+        self._state['index_term'] = dict()
 
     class TermIndex(dict):
         """Map term to index."""
@@ -44,12 +55,10 @@ class Vocabulary(StatefulUnit):
 
     def fit(self, tokens: list):
         """Build a :class:`TermIndex` and a :class:`IndexTerm`."""
-        self._state['term_index'] = self.TermIndex()
-        self._state['index_term'] = dict()
-        self._state['term_index']['<PAD>'] = 0
-        self._state['term_index']['<OOV>'] = 1
-        self._state['index_term'][0] = '<PAD>'
-        self._state['index_term'][1] = '<OOV>'
+        self._state['term_index'][self._pad] = 0
+        self._state['term_index'][self._oov] = 1
+        self._state['index_term'][0] = self._pad
+        self._state['index_term'][1] = self._oov
         terms = set(tokens)
         for index, term in enumerate(terms):
             self._state['term_index'][term] = index + 2

--- a/matchzoo/preprocessors/units/word_hashing.py
+++ b/matchzoo/preprocessors/units/word_hashing.py
@@ -19,12 +19,14 @@ class WordHashing(Unit):
     Examples:
        >>> letters = [['#te', 'tes','est', 'st#'], ['oov']]
        >>> word_hashing = WordHashing(
-       ...     term_index={'': 0,'st#': 1, '#te': 2, 'est': 3, 'tes': 4})
+       ...     term_index={
+       ...      '_PAD': 0, 'OOV': 1, 'st#': 2, '#te': 3, 'est': 4, 'tes': 5
+       ...      })
        >>> hashing = word_hashing.transform(letters)
        >>> hashing[0]
-       [0.0, 1.0, 1.0, 1.0, 1.0, 0.0]
+       [0.0, 0.0, 1.0, 1.0, 1.0, 1.0]
        >>> hashing[1]
-       [1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+       [0.0, 1.0, 0.0, 0.0, 0.0, 0.0]
 
     """
 
@@ -52,18 +54,18 @@ class WordHashing(Unit):
         if any([isinstance(elem, list) for elem in input_]):
             # The input shape for CDSSM is
             # [[word1 ngram, ngram], [word2, ngram, ngram], ...].
-            hashing = np.zeros((len(input_), len(self._term_index) + 1))
+            hashing = np.zeros((len(input_), len(self._term_index)))
             for idx, word in enumerate(input_):
                 counted_letters = collections.Counter(word)
                 for key, value in counted_letters.items():
-                    letter_id = self._term_index.get(key, 0)
+                    letter_id = self._term_index.get(key, 1)
                     hashing[idx, letter_id] = value
         else:
             # The input shape for DSSM model [ngram, ngram, ...].
-            hashing = np.zeros((len(self._term_index) + 1))
+            hashing = np.zeros(len(self._term_index))
             counted_letters = collections.Counter(input_)
             for key, value in counted_letters.items():
-                letter_id = self._term_index.get(key, 0)
+                letter_id = self._term_index.get(key, 1)
                 hashing[letter_id] = value
 
         return hashing.tolist()

--- a/tests/unit_test/test_embedding.py
+++ b/tests/unit_test/test_embedding.py
@@ -5,15 +5,15 @@ import matchzoo as mz
 
 @pytest.fixture
 def term_index():
-    return {'G': 1, 'C': 2, 'D': 3, 'A': 4, '[PAD]': 0}
+    return {'G': 1, 'C': 2, 'D': 3, 'A': 4, '_PAD': 0}
 
 
 def test_embedding(term_index):
     embed = mz.embedding.load_from_file(mz.datasets.embeddings.EMBED_RANK)
     matrix = embed.build_matrix(term_index)
-    assert matrix.shape == (len(term_index) + 1, 50)
+    assert matrix.shape == (len(term_index), 50)
     embed = mz.embedding.load_from_file(mz.datasets.embeddings.EMBED_10_GLOVE,
                                         mode='glove')
     matrix = embed.build_matrix(term_index)
-    assert matrix.shape == (len(term_index) + 1, 10)
+    assert matrix.shape == (len(term_index), 10)
     assert embed.input_dim == 5


### PR DESCRIPTION
It is important to separate OOV with PAD by different indices. For keras, the PAD is assumed at the index `0`. That's the basic to support the `mask_zero` in `Embedding` layer. Thus, I have placed the `PAD` at the index `0` and `OOV` at the index `1` in the `Vocabulary`.  By updating this, I have witnessed the improvement of `MVLSTM` (e,g. from 0.63 to 0.66) on WikiQA. More experiments need to be conducted on the tutorials of WikiQA.