### PR TITLE
[Feature] Optimizers with LR multipliers

### DIFF
--- a/matchzoo/__init__.py
+++ b/matchzoo/__init__.py
@@ -33,6 +33,7 @@ from . import datasets
 from . import layers
 from . import auto
 from . import contrib
+from . import optimizers
 
 from .engine import hyper_spaces
 from .engine.base_model import load_model

--- a/matchzoo/optimizers/__init__.py
+++ b/matchzoo/optimizers/__init__.py
@@ -1,0 +1,13 @@
+from .multi_optimizer import MultiOptimizer
+from .multi_sgd import MultiSGD
+from .multi_rmsprop import MultiRMSprop
+from .multi_adagrad import MultiAdagrad
+from .multi_adadelta import MultiAdadelta
+from .multi_adam import MultiAdam
+from .multi_adamax import MultiAdamax
+from .multi_nadam import MultiNadam
+
+
+def list_available() -> list:
+    from matchzoo.utils import list_recursive_concrete_subclasses
+    return list_recursive_concrete_subclasses(MultiOptimizer)

--- a/matchzoo/optimizers/multi_adadelta.py
+++ b/matchzoo/optimizers/multi_adadelta.py
@@ -1,0 +1,113 @@
+"""Adadelta optimizer wiht LR multipliers."""
+import typing
+
+import keras
+import keras.backend as K
+from keras.legacy import interfaces
+
+import matchzoo
+from matchzoo.optimizers import MultiOptimizer
+
+
+class MultiAdadelta(MultiOptimizer):
+    """Adadelta optimizer with LR multipliers.
+
+    Adadelta is a more robust extension of Adagrad
+    that adapts learning rates based on a moving window of gradient updates,
+    instead of accumulating all past gradients. This way, Adadelta continues
+    learning even when many updates have been done. Compared to Adagrad, in the
+    original version of Adadelta you don't have to set an initial learning
+    rate. In this version, initial learning rate and decay factor can
+    be set, as in most other Keras optimizers.
+
+    It is recommended to leave the parameters of this optimizer
+    at their default values.
+
+    :param lr: Float >= 0. Initial learning rate, defaults to 1.
+        It is recommended to leave it at the default value.
+    :param rho: Float >= 0. Adadelta decay factor, corresponding to fraction of
+        gradient to keep at each time step.
+        epsilon: float >= 0. Fuzz factor. If `None`, defaults to `K.epsilon()`.
+        decay: float >= 0. Initial learning rate decay.
+    :param multipliers: Dict. Different learning rate multiplier for
+        different layers. For example, `multipliers={'dense_1':0.8,
+        'conv_1/kernel':0.5}.
+
+    Example:
+        >>> import matchzoo as mz
+        >>> multi_optimizer = mz.optimizer.MultiAdadelta(
+        ...    multipliers={'dense_1':0.8, 'conv_1/kernel':0.5}
+        ... )
+
+    # References
+        - [Adadelta - an adaptive learning rate method]
+          (https://arxiv.org/abs/1212.5701)
+    """
+
+    def __init__(self, lr=1.0, rho=0.95, epsilon=None, decay=0.,
+                 multipliers=None, **kwargs):
+        super().__init__()
+        with K.name_scope(self.__class__.__name__):
+            self.lr = K.variable(lr, name='lr')
+            self.decay = K.variable(decay, name='decay')
+            self.iterations = K.variable(0, dtype='int64', name='iterations')
+        if epsilon is None:
+            epsilon = K.epsilon()
+        self.rho = rho
+        self.epsilon = epsilon
+        self.initial_decay = decay
+        self.multipliers = multipliers
+
+    @interfaces.legacy_get_updates_support
+    def get_updates(self, loss, params):
+        grads = self.get_gradients(loss, params)
+        shapes = [K.int_shape(p) for p in params]
+        accumulators = [K.zeros(shape) for shape in shapes]
+        delta_accumulators = [K.zeros(shape) for shape in shapes]
+        self.weights = accumulators + delta_accumulators
+        self.updates = [K.update_add(self.iterations, 1)]
+
+        lr = self.lr
+        if self.initial_decay > 0:
+            lr = lr * (1. / (1. + self.decay * K.cast(self.iterations,
+                                                      K.dtype(self.decay))))
+
+        for p, g, a, d_a in zip(params, grads, accumulators,
+                                delta_accumulators):
+
+            # Get learning rate multiplier
+            multiplier = self.get_multiplier(p)
+
+            # Get new learning rate
+            new_lr = lr
+            if multiplier:
+                new_lr = lr * multiplier
+
+            # update accumulator
+            new_a = self.rho * a + (1. - self.rho) * K.square(g)
+            self.updates.append(K.update(a, new_a))
+
+            # use the new accumulator and the *old* delta_accumulator
+            update = g * K.sqrt(d_a + self.epsilon) / (
+                K.sqrt(new_a + self.epsilon))
+            new_p = p - new_lr * update
+
+            # Apply constraints.
+            if getattr(p, 'constraint', None) is not None:
+                new_p = p.constraint(new_p)
+
+            self.updates.append(K.update(p, new_p))
+
+            # update delta_accumulator
+            new_d_a = self.rho * d_a + (1 - self.rho) * K.square(update)
+            self.updates.append(K.update(d_a, new_d_a))
+        return self.updates
+
+    def get_config(self):
+        config = {'lr': float(K.get_value(self.lr)),
+                  'rho': self.rho,
+                  'decay': float(K.get_value(self.decay)),
+                  'epsilon': self.epsilon,
+                  'multipliers': self.multipliers}
+        base_config = super(MultiAdadelta, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/matchzoo/optimizers/multi_adagrad.py
+++ b/matchzoo/optimizers/multi_adagrad.py
@@ -1,0 +1,96 @@
+"""Adagrad optimizer wiht LR multipliers."""
+import typing
+
+import keras
+import keras.backend as K
+from keras.legacy import interfaces
+
+import matchzoo
+from matchzoo.optimizers import MultiOptimizer
+
+
+class MultiAdagrad(MultiOptimizer):
+    """Adagrad optimizer with LR multipliers.
+
+    Adagrad is an optimizer with parameter-specific learning rates,
+    which are adapted relative to how frequently a parameter gets
+    updated during training. The more updates a parameter receives,
+    the smaller the updates.
+
+    It is recommended to leave the parameters of this optimizer
+    at their default values.
+
+    :param lr: Float >= 0. Initial learning rate.
+    :param epsilon: Float >= 0. If `None`, defaults to `K.epsilon()`.
+    :param decay: Float >= 0. Learning rate decay over each update.
+
+    :param nesterov: Bool. Whether to apply Nesterov momentum.
+    :param multipliers: Dict. Different learning rate multiplier for
+        different layers. For example, `multipliers={'dense_1':0.8,
+        'conv_1/kernel':0.5}.
+
+    Example:
+        >>> import matchzoo as mz
+        >>> multi_optimizer = mz.optimizer.MultiAdagrad(
+        ...    multipliers={'dense_1':0.8, 'conv_1/kernel':0.5}
+        ... )
+
+    # References
+        - [Adaptive Subgradient Methods for Online Learning and Stochastic
+           Optimization](http://www.jmlr.org/papers/volume12/duchi11a/duchi11a.pdf)
+    """
+
+    def __init__(self, lr=0.01, epsilon=None, decay=0.,
+                 multipliers=None, **kwargs):
+        super().__init__()
+        with K.name_scope(self.__class__.__name__):
+            self.lr = K.variable(lr, name='lr')
+            self.decay = K.variable(decay, name='decay')
+            self.iterations = K.variable(0, dtype='int64', name='iterations')
+        if epsilon is None:
+            epsilon = K.epsilon()
+        self.epsilon = epsilon
+        self.initial_decay = decay
+        self.multipliers = multipliers
+
+    @interfaces.legacy_get_updates_support
+    def get_updates(self, loss, params):
+        grads = self.get_gradients(loss, params)
+        shapes = [K.int_shape(p) for p in params]
+        accumulators = [K.zeros(shape) for shape in shapes]
+        self.weights = accumulators
+        self.updates = [K.update_add(self.iterations, 1)]
+
+        lr = self.lr
+        if self.initial_decay > 0:
+            lr = lr * (1. / (1. + self.decay * K.cast(self.iterations,
+                                                      K.dtype(self.decay))))
+
+        for p, g, a in zip(params, grads, accumulators):
+
+            # Get learning rate multiplier
+            multiplier = self.get_multiplier(p)
+
+            # Get new learning rate
+            new_lr = lr
+            if multiplier:
+                new_lr = lr * multiplier
+
+            new_a = a + K.square(g)  # update accumulator
+            self.updates.append(K.update(a, new_a))
+            new_p = p - new_lr * g / (K.sqrt(new_a) + self.epsilon)
+
+            # Apply constraints.
+            if getattr(p, 'constraint', None) is not None:
+                new_p = p.constraint(new_p)
+
+            self.updates.append(K.update(p, new_p))
+        return self.updates
+
+    def get_config(self):
+        config = {'lr': float(K.get_value(self.lr)),
+                  'decay': float(K.get_value(self.decay)),
+                  'epsilon': self.epsilon,
+                  'multipliers': self.multipliers}
+        base_config = super(MultiAdagrad, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/matchzoo/optimizers/multi_adam.py
+++ b/matchzoo/optimizers/multi_adam.py
@@ -1,0 +1,121 @@
+"""Adam optimizer with LR multipliers"""
+import typing
+
+import keras
+import keras.backend as K
+from keras.legacy import interfaces
+
+import matchzoo
+from matchzoo.optimizers import MultiOptimizer
+
+
+class MultiAdam(MultiOptimizer):
+    """Adam optimizer with LR multipliers.
+
+    Default parameters follow those provided in the original paper.
+
+    :param lr: Float >= 0. Learning rate.
+    :param beta_1: Float, 0 < beta < 1. Generally close to 1.
+    :param beta_2: Float, 0 < beta < 1. Generally close to 1.
+    :param epsilon: Float >= 0. Fuzz factor. If `None`, defaults to
+        `K.epsilon()`.
+    :param decay: Float >= 0. Learning rate decay over each update.
+    :param amsgrad: Bool. Whether to apply the AMSGrad variant of this
+        algorithm from the paper "On the Convergence of Adam and
+        Beyond".
+    :param multipliers: Dict. Different learning rate multiplier for
+        different layers. For example, `multipliers={'dense_1':0.8,
+        'conv_1/kernel':0.5}.
+
+    Example:
+        >>> import matchzoo as mz
+        >>> multi_optimizer = mz.optimizer.MultiAdam(
+        ...    multipliers={'dense_1':0.8, 'conv_1/kernel':0.5}
+        ... )
+
+    # References
+        - [Adam - A Method for Stochastic Optimization]
+          (https://arxiv.org/abs/1412.6980v8)
+        - [On the Convergence of Adam and Beyond]
+          (https://openreview.net/forum?id=ryQu7f-RZ)
+    """
+
+    def __init__(self, lr=0.001, beta_1=0.9, beta_2=0.999,
+                 epsilon=None, decay=0., amsgrad=False,
+                 multipliers=None, **kwargs):
+        super().__init__()
+        with K.name_scope(self.__class__.__name__):
+            self.iterations = K.variable(0, dtype='int64', name='iterations')
+            self.lr = K.variable(lr, name='lr')
+            self.beta_1 = K.variable(beta_1, name='beta_1')
+            self.beta_2 = K.variable(beta_2, name='beta_2')
+            self.decay = K.variable(decay, name='decay')
+        if epsilon is None:
+            epsilon = K.epsilon()
+        self.epsilon = epsilon
+        self.initial_decay = decay
+        self.amsgrad = amsgrad
+        self.multipliers = multipliers
+
+    @interfaces.legacy_get_updates_support
+    def get_updates(self, loss, params):
+        grads = self.get_gradients(loss, params)
+        self.updates = [K.update_add(self.iterations, 1)]
+
+        lr = self.lr
+        if self.initial_decay > 0:
+            lr = lr * (1. / (1. + self.decay * K.cast(self.iterations,
+                                                      K.dtype(self.decay))))
+
+        t = K.cast(self.iterations, K.floatx()) + 1
+        lr_t = lr * (K.sqrt(1. - K.pow(self.beta_2, t)) / (
+            (1. - K.pow(self.beta_1, t))))
+
+        ms = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
+        vs = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
+        if self.amsgrad:
+            vhats = [K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params]
+        else:
+            vhats = [K.zeros(1) for _ in params]
+        self.weights = [self.iterations] + ms + vs + vhats
+
+        for p, g, m, v, vhat in zip(params, grads, ms, vs, vhats):
+
+            # Get learning rate multiplier
+            multiplier = self.get_multiplier(p)
+
+            # Get new learning rate
+            new_lr_t = lr_t
+            if multiplier:
+                new_lr_t = lr_t * multiplier
+
+            m_t = (self.beta_1 * m) + (1. - self.beta_1) * g
+            v_t = (self.beta_2 * v) + (1. - self.beta_2) * K.square(g)
+            if self.amsgrad:
+                vhat_t = K.maximum(vhat, v_t)
+                p_t = p - new_lr_t * m_t / (K.sqrt(vhat_t) + self.epsilon)
+                self.updates.append(K.update(vhat, vhat_t))
+            else:
+                p_t = p - new_lr_t * m_t / (K.sqrt(v_t) + self.epsilon)
+
+            self.updates.append(K.update(m, m_t))
+            self.updates.append(K.update(v, v_t))
+            new_p = p_t
+
+            # Apply constraints.
+            if getattr(p, 'constraint', None) is not None:
+                new_p = p.constraint(new_p)
+
+            self.updates.append(K.update(p, new_p))
+        return self.updates
+
+    def get_config(self):
+        config = {'lr': float(K.get_value(self.lr)),
+                  'beta_1': float(K.get_value(self.beta_1)),
+                  'beta_2': float(K.get_value(self.beta_2)),
+                  'decay': float(K.get_value(self.decay)),
+                  'epsilon': self.epsilon,
+                  'amsgrad': self.amsgrad,
+                  'multipliers': self.multipliers}
+        base_config = super(MultiAdam, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/matchzoo/optimizers/multi_adamax.py
+++ b/matchzoo/optimizers/multi_adamax.py
@@ -1,0 +1,104 @@
+"""Adamax optimizer with LR multipliers."""
+import typing
+
+import keras
+import keras.backend as K
+from keras.legacy import interfaces
+
+import matchzoo
+from matchzoo.optimizers import MultiOptimizer
+
+
+class MultiAdamax(MultiOptimizer):
+    """Adamax optimizer from Adam paper's Section 7 with LR multipliers.
+
+    It is a variant of Adam based on the infinity norm.
+    Default parameters follow those provided in the paper.
+
+    :param lr: Float >= 0. Learning rate.
+    :param beta_1/beta_2: Floats, 0 < beta < 1. Generally close to 1.
+    :param epsilon: Float >= 0. Fuzz factor. If `None`, defaults to
+        `K.epsilon()`.
+    :param decay: float >= 0. Learning rate decay over each update.
+
+    Example:
+        >>> import matchzoo as mz
+        >>> multi_optimizer = mz.optimizer.MultiAdamax(
+        ...    multipliers={'dense_1':0.8, 'conv_1/kernel':0.5}
+        ... )
+
+    # References
+        - [Adam - A Method for Stochastic Optimization]
+          (https://arxiv.org/abs/1412.6980v8)
+    """
+
+    def __init__(self, lr=0.002, beta_1=0.9, beta_2=0.999,
+                 epsilon=None, decay=0., multipliers=None,
+                 **kwargs):
+        super().__init__()
+        with K.name_scope(self.__class__.__name__):
+            self.iterations = K.variable(0, dtype='int64', name='iterations')
+            self.lr = K.variable(lr, name='lr')
+            self.beta_1 = K.variable(beta_1, name='beta_1')
+            self.beta_2 = K.variable(beta_2, name='beta_2')
+            self.decay = K.variable(decay, name='decay')
+        if epsilon is None:
+            epsilon = K.epsilon()
+        self.epsilon = epsilon
+        self.initial_decay = decay
+        self.multipliers = multipliers
+
+    @interfaces.legacy_get_updates_support
+    def get_updates(self, loss, params):
+        grads = self.get_gradients(loss, params)
+        self.updates = [K.update_add(self.iterations, 1)]
+
+        lr = self.lr
+        if self.initial_decay > 0:
+            lr = lr * (1. / (1. + self.decay * K.cast(self.iterations,
+                                                      K.dtype(self.decay))))
+
+        t = K.cast(self.iterations, K.floatx()) + 1
+        lr_t = lr / (1. - K.pow(self.beta_1, t))
+
+        shapes = [K.int_shape(p) for p in params]
+        # zero init of 1st moment
+        ms = [K.zeros(shape) for shape in shapes]
+        # zero init of exponentially weighted infinity norm
+        us = [K.zeros(shape) for shape in shapes]
+        self.weights = [self.iterations] + ms + us
+
+        for p, g, m, u in zip(params, grads, ms, us):
+
+            # Get learning rate multiplier
+            multiplier = self.get_multiplier(p)
+
+            # Get new learning rate
+            new_lr_t = lr_t
+            if multiplier:
+                new_lr_t = lr_t * multiplier
+
+            m_t = (self.beta_1 * m) + (1. - self.beta_1) * g
+            u_t = K.maximum(self.beta_2 * u, K.abs(g))
+            p_t = p - new_lr_t * m_t / (u_t + self.epsilon)
+
+            self.updates.append(K.update(m, m_t))
+            self.updates.append(K.update(u, u_t))
+            new_p = p_t
+
+            # Apply constraints.
+            if getattr(p, 'constraint', None) is not None:
+                new_p = p.constraint(new_p)
+
+            self.updates.append(K.update(p, new_p))
+        return self.updates
+
+    def get_config(self):
+        config = {'lr': float(K.get_value(self.lr)),
+                  'beta_1': float(K.get_value(self.beta_1)),
+                  'beta_2': float(K.get_value(self.beta_2)),
+                  'decay': float(K.get_value(self.decay)),
+                  'epsilon': self.epsilon,
+                  'multipliers': self.multipliers}
+        base_config = super(MultiAdamax, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/matchzoo/optimizers/multi_nadam.py
+++ b/matchzoo/optimizers/multi_nadam.py
@@ -1,0 +1,121 @@
+"""Nadam optimizer with LR multipliers."""
+import typing
+
+import keras
+import keras.backend as K
+from keras.legacy import interfaces
+
+import matchzoo
+from matchzoo.optimizers import MultiOptimizer
+
+
+class MultiNadam(MultiOptimizer):
+    """Nesterov Adam optimizer with LR multipliers.
+
+    Much like Adam is essentially RMSprop with momentum,
+    Nadam is Adam RMSprop with Nesterov momentum.
+
+    Default parameters follow those provided in the paper.
+    It is recommended to leave the parameters of this optimizer
+    at their default values.
+
+    :param lr: Float >= 0. Learning rate.
+    :param beta_1/beta_2: Floats, 0 < beta < 1. Generally close to 1.
+    :param epsilon: Float >= 0. Fuzz factor. If `None`, defaults to
+        `K.epsilon()`.
+    :param multipliers: Dict. Different learning rate multiplier for
+        different layers. For example, `multipliers={'dense_1':0.8,
+        'conv_1/kernel':0.5}.
+
+    Example:
+        >>> import matchzoo as mz
+        >>> multi_optimizer = mz.optimizer.MultiNadam(
+        ...    multipliers={'dense_1':0.8, 'conv_1/kernel':0.5}
+        ... )
+
+    # References
+        - [Nadam report](http://cs229.stanford.edu/proj2015/054_report.pdf)
+        - [On the importance of initialization and momentum in deep learning]
+          (http://www.cs.toronto.edu/~fritz/absps/momentum.pdf)
+    """
+
+    def __init__(self, lr=0.002, beta_1=0.9, beta_2=0.999,
+                 epsilon=None, schedule_decay=0.004,
+                 multipliers=None, **kwargs):
+        super().__init__()
+        with K.name_scope(self.__class__.__name__):
+            self.iterations = K.variable(0, dtype='int64', name='iterations')
+            self.m_schedule = K.variable(1., name='m_schedule')
+            self.lr = K.variable(lr, name='lr')
+            self.beta_1 = K.variable(beta_1, name='beta_1')
+            self.beta_2 = K.variable(beta_2, name='beta_2')
+        if epsilon is None:
+            epsilon = K.epsilon()
+        self.epsilon = epsilon
+        self.schedule_decay = schedule_decay
+        self.multipliers = multipliers
+
+    @interfaces.legacy_get_updates_support
+    def get_updates(self, loss, params):
+        grads = self.get_gradients(loss, params)
+        self.updates = [K.update_add(self.iterations, 1)]
+
+        t = K.cast(self.iterations, K.floatx()) + 1
+
+        # Due to the recommendations in [2], i.e. warming momentum schedule
+        momentum_cache_t = self.beta_1 * (1. - 0.5 * (
+            K.pow(K.cast_to_floatx(0.96), t * self.schedule_decay)))
+        momentum_cache_t_1 = self.beta_1 * (1. - 0.5 * (
+            K.pow(K.cast_to_floatx(0.96), (t + 1) * self.schedule_decay)))
+        m_schedule_new = self.m_schedule * momentum_cache_t
+        m_schedule_next = self.m_schedule * momentum_cache_t * (
+            momentum_cache_t_1)
+        self.updates.append((self.m_schedule, m_schedule_new))
+
+        shapes = [K.int_shape(p) for p in params]
+        ms = [K.zeros(shape) for shape in shapes]
+        vs = [K.zeros(shape) for shape in shapes]
+
+        self.weights = [self.iterations] + ms + vs
+
+        for p, g, m, v in zip(params, grads, ms, vs):
+
+            # Get learning rate multiplier
+            multiplier = self.get_multiplier(p)
+
+            # Get new learning rate
+            new_lr = self.lr
+            if multiplier:
+                new_lr = self.lr * multiplier
+
+            # the following equations given in [1]
+            g_prime = g / (1. - m_schedule_new)
+            m_t = self.beta_1 * m + (1. - self.beta_1) * g
+            m_t_prime = m_t / (1. - m_schedule_next)
+            v_t = self.beta_2 * v + (1. - self.beta_2) * K.square(g)
+            v_t_prime = v_t / (1. - K.pow(self.beta_2, t))
+            m_t_bar = (1. - momentum_cache_t) * g_prime + (
+                momentum_cache_t_1 * m_t_prime)
+
+            self.updates.append(K.update(m, m_t))
+            self.updates.append(K.update(v, v_t))
+
+            p_t = p - new_lr * m_t_bar / (K.sqrt(v_t_prime) + self.epsilon)
+            new_p = p_t
+
+            # Apply constraints.
+            if getattr(p, 'constraint', None) is not None:
+                new_p = p.constraint(new_p)
+
+            self.updates.append(K.update(p, new_p))
+        return self.updates
+
+    def get_config(self):
+        config = {'lr': float(K.get_value(self.lr)),
+                  'beta_1': float(K.get_value(self.beta_1)),
+                  'beta_2': float(K.get_value(self.beta_2)),
+                  'epsilon': self.epsilon,
+                  'schedule_decay': self.schedule_decay,
+                  'multipliers': self.multipliers}
+        base_config = super(MultiNadam, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/matchzoo/optimizers/multi_optimizer.py
+++ b/matchzoo/optimizers/multi_optimizer.py
@@ -1,0 +1,30 @@
+"""Optimizer with LR multipliers."""
+import typing
+
+import keras
+import keras.backend as K
+from keras.optimizers import Optimizer
+from keras.legacy import interfaces
+
+
+class MultiOptimizer(Optimizer):
+    """Abstract optimizer with LR multipliers base class.
+
+    Note: this is the parent class of all multi optimizers, not an actual
+    optimizer that can be used for training models.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__()
+
+    @interfaces.legacy_get_updates_support
+    def get_updates(self, loss, params):
+        raise NotImplementedError
+
+    def get_multiplier(self, param):
+        if self.multipliers is not None:
+            for k in self.multipliers.keys():
+                if k in param.name:
+                    return self.multipliers[k]
+            return None
+        return None

--- a/matchzoo/optimizers/multi_rmsprop.py
+++ b/matchzoo/optimizers/multi_rmsprop.py
@@ -1,0 +1,100 @@
+"""RMSProp optimizer wiht LR multipliers."""
+import typing
+
+import keras
+import keras.backend as K
+from keras.legacy import interfaces
+
+import matchzoo
+from matchzoo.optimizers import MultiOptimizer
+
+
+class MultiRMSprop(MultiOptimizer):
+    """RMSProp optimizer with LR multipliers.
+
+    It is recommended to leave the parameters of this optimizer
+    at their default values
+    (except the learning rate, which can be freely tuned).
+
+    This optimizer is usually a good choice for recurrent
+    neural networks.
+
+    :param lr: Float >= 0. Learning rate.
+    :param rho: Float >= 0.
+    :param epsilon: Float >= 0. Fuzz factor. If `None`, defaults to
+        `K.epsilon()`.
+    :param decay: Float >= 0. Learning rate decay over each update.
+    :param multipliers: Dict. Different learning rate multiplier for
+        different layers. For example, `multipliers={'dense_1':0.8,
+        'conv_1/kernel':0.5}.
+
+    Example:
+        >>> import matchzoo as mz
+        >>> multi_optimizer = mz.optimizer.MultiRMSprop(
+        ...    multipliers={'dense_1':0.8, 'conv_1/kernel':0.5}
+        ... )
+
+    # References
+        - [rmsprop: Divide the gradient by a running average of its
+           recent magnitude](http://www.cs.toronto.edu/~tijmen/csc321/
+           slides/lecture_slides_lec6.pdf)
+    """
+
+    def __init__(self, lr=0.001, rho=0.9, epsilon=None, decay=0.,
+                 multipliers=None, **kwargs):
+        super().__init__()
+        with K.name_scope(self.__class__.__name__):
+            self.lr = K.variable(lr, name='lr')
+            self.rho = K.variable(rho, name='rho')
+            self.decay = K.variable(decay, name='decay')
+            self.iterations = K.variable(0, dtype='int64', name='iterations')
+        if epsilon is None:
+            epsilon = K.epsilon()
+        self.epsilon = epsilon
+        self.initial_decay = decay
+        self.multipliers = multipliers
+
+    @interfaces.legacy_get_updates_support
+    def get_updates(self, loss, params):
+        grads = self.get_gradients(loss, params)
+        accumulators = [
+            K.zeros(K.int_shape(p), dtype=K.dtype(p)) for p in params
+        ]
+        self.weights = accumulators
+        self.updates = [K.update_add(self.iterations, 1)]
+
+        lr = self.lr
+        if self.initial_decay > 0:
+            lr = lr * (1. / (1. + self.decay * K.cast(self.iterations,
+                                                      K.dtype(self.decay))))
+
+        for p, g, a in zip(params, grads, accumulators):
+
+            # Get learning rate multiplier
+            multiplier = self.get_multiplier(p)
+
+            # Get new learning rate
+            new_lr = lr
+            if multiplier:
+                new_lr = lr * multiplier
+
+            # update accumulator
+            new_a = self.rho * a + (1. - self.rho) * K.square(g)
+            self.updates.append(K.update(a, new_a))
+            new_p = p - new_lr * g / (K.sqrt(new_a) + self.epsilon)
+
+            # Apply constraints.
+            if getattr(p, 'constraint', None) is not None:
+                new_p = p.constraint(new_p)
+
+            self.updates.append(K.update(p, new_p))
+        return self.updates
+
+    def get_config(self):
+        config = {'lr': float(K.get_value(self.lr)),
+                  'rho': float(K.get_value(self.rho)),
+                  'decay': float(K.get_value(self.decay)),
+                  'epsilon': self.epsilon,
+                  'multipliers': self.multipliers}
+        base_config = super(MultiRMSprop, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/matchzoo/optimizers/multi_sgd.py
+++ b/matchzoo/optimizers/multi_sgd.py
@@ -1,0 +1,91 @@
+"""Stochastic gradient descent optimizer with LR multipliers."""
+import typing
+
+import keras
+import keras.backend as K
+from keras.legacy import interfaces
+
+import matchzoo
+from matchzoo.optimizers import MultiOptimizer
+
+
+class MultiSGD(MultiOptimizer):
+    """Stochastic gradient descent optimizer with LR multiplier.
+
+    Includes support for momentum,
+    learning rate decay, Nesterov momentum.
+
+    :param lr: Float >= 0. Learning rate.
+    :param momentum: Float >= 0. Parameter that accelerates SGD
+        in the relevant direction and dampens oscillations.
+    :param decay: Float >= 0. Learning rate decay over each update.
+    :param nesterov: Bool. Whether to apply Nesterov momentum.
+    :param multipliers: Dict. Different learning rate multiplier for
+        different layers. For example, `multipliers={'dense_1':0.8,
+        'conv_1/kernel':0.5}.
+
+    Example:
+        >>> import matchzoo as mz
+        >>> multi_optimizer = mz.optimizer.MultiSGD(
+        ...    multipliers={'dense_1':0.8, 'conv_1/kernel':0.5}
+        ... )
+    """
+
+    def __init__(self, lr=0.01, momentum=0., decay=0.,
+                 nesterov=False, multipliers=None, **kwargs):
+        super().__init__()
+        with K.name_scope(self.__class__.__name__):
+            self.iterations = K.variable(0, dtype='int64', name='iterations')
+            self.lr = K.variable(lr, name='lr')
+            self.momentum = K.variable(momentum, name='momentum')
+            self.decay = K.variable(decay, name='decay')
+        self.initial_decay = decay
+        self.nesterov = nesterov
+        self.multipliers = multipliers
+
+    @interfaces.legacy_get_updates_support
+    def get_updates(self, loss, params):
+        grads = self.get_gradients(loss, params)
+        self.updates = [K.update_add(self.iterations, 1)]
+
+        lr = self.lr
+        if self.initial_decay > 0:
+            lr = lr * (1. / (1. + self.decay * K.cast(self.iterations,
+                                                      K.dtype(self.decay))))
+        # momentum
+        shapes = [K.int_shape(p) for p in params]
+        moments = [K.zeros(shape) for shape in shapes]
+        self.weights = [self.iterations] + moments
+        for p, g, m in zip(params, grads, moments):
+
+            # Get learning rate multiplier
+            multiplier = self.get_multiplier(p)
+
+            # Get new learning rate
+            new_lr = lr
+            if multiplier:
+                new_lr = lr * multiplier
+
+            v = self.momentum * m - new_lr * g  # velocity
+            self.updates.append(K.update(m, v))
+
+            if self.nesterov:
+                new_p = p + self.momentum * v - new_lr * g
+            else:
+                new_p = p + v
+
+            # Apply constraints.
+            if getattr(p, 'constraint', None) is not None:
+                new_p = p.constraint(new_p)
+
+            self.updates.append(K.update(p, new_p))
+        return self.updates
+
+    def get_config(self):
+        config = {'lr': float(K.get_value(self.lr)),
+                  'momentum': float(K.get_value(self.momentum)),
+                  'decay': float(K.get_value(self.decay)),
+                  'nesterov': self.nesterov,
+                  'multipliers': self.multipliers}
+        base_config = super(MultiSGD, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/tests/unit_test/optimizers/test_optimizers.py
+++ b/tests/unit_test/optimizers/test_optimizers.py
@@ -1,0 +1,83 @@
+import pytest
+import numpy as np
+import keras
+from keras.models import Sequential
+from keras.layers import Dense, Activation
+from keras.utils import to_categorical
+
+import matchzoo as mz
+
+
+@pytest.fixture(scope='module')
+def data(num_train=1000, num_test=500, input_shape=(10,),
+         output_shape=(2,), classification=True, num_classes=2):
+    """Generates test data to train a model on.
+    classification=True overrides output_shape
+    (i.e. output_shape is set to (1,)) and the output
+    consists in integers in [0, num_class-1].
+    Otherwise: float output with shape output_shape.
+    """
+    samples = num_train + num_test
+    if classification:
+        y = np.random.randint(0, num_classes, size=(samples,))
+        X = np.zeros((samples,) + input_shape)
+        for i in range(samples):
+            X[i] = np.random.normal(loc=y[i], scale=0.7, size=input_shape)
+    else:
+        y_loc = np.random.random((samples,))
+        X = np.zeros((samples,) + input_shape)
+        y = np.zeros((samples,) + output_shape)
+        for i in range(samples):
+            X[i] = np.random.normal(loc=y_loc[i], scale=0.7, size=input_shape)
+            y[i] = np.random.normal(loc=y_loc[i], scale=0.7, size=output_shape)
+
+    x_train, y_train = X[:num_train], y[:num_train]
+    y_train = to_categorical(y_train)
+    return x_train, y_train
+
+
+@pytest.fixture(scope='module')
+def model(data):
+    x_train, y_train = data
+    model = Sequential()
+    model.add(Dense(10, input_shape=(x_train.shape[1],)))
+    model.add(Activation('relu'))
+    model.add(Dense(y_train.shape[1]))
+    model.add(Activation('softmax'))
+    return model
+
+
+@pytest.fixture(scope='module', params=[
+    {'dense_1/kernel:0': 0.8},
+    {'dense_1': 0.5},
+    {}
+])
+def multipliers(request):
+    return request.param
+
+
+@pytest.fixture(scope='module', params=mz.optimizers.list_available())
+def optimizer_class(request):
+    return request.param
+
+
+@pytest.fixture(scope='module')
+def optimizer(optimizer_class, multipliers):
+    optimizer = optimizer_class(multipliers=multipliers)
+    return optimizer
+
+
+@pytest.mark.cron
+def test_optimizer(data, model, optimizer, target=0.75):
+    x_train, y_train = data
+    model.compile(loss='categorical_crossentropy',
+                  optimizer=optimizer,
+                  metrics=['accuracy'])
+    history = model.fit(x_train, y_train, epochs=10, batch_size=16, verbose=0)
+    assert history.history['acc'][-1] >= target
+
+    config = keras.optimizers.serialize(optimizer)
+    custom_objects = {optimizer.__class__.__name__: optimizer.__class__}
+    optim = keras.optimizers.deserialize(config, custom_objects)
+    new_config = keras.optimizers.serialize(optim)
+    assert config == new_config


### PR DESCRIPTION
This PR implements optimizers with learning rate multipliers, which can be used to apply different learning rates for different layers. For example:

```python
optimizer = MultiSGD(multipliers={'dense_1': 0.8})
```

In this example, parameter `multipliers` indicates that layers whose name contain `dense_1` have a learning rate multiplier of 0.8 with respect to global learning rate.

### Related issue
#728 