### PR TITLE
Update rank_cross_entropy_loss to avoid NANs

### DIFF
--- a/matchzoo/losses/rank_cross_entropy_loss.py
+++ b/matchzoo/losses/rank_cross_entropy_loss.py
@@ -48,7 +48,7 @@ class RankCrossEntropyLoss(object):
             labels.append(neg_labels)
         logits = K.concatenate(logits, axis=-1)
         labels = K.concatenate(labels, axis=-1)
-        return -K.mean(K.sum(labels * K.log(K.softmax(logits)), axis=-1))
+        return -K.mean(K.sum(labels * K.log(K.softmax(logits) + np.finfo(float).eps), axis=-1))
 
     @property
     def num_neg(self):


### PR DESCRIPTION
Added an epsilon in the log of the rank cross entropy loss