### PR TITLE
add support for keras 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
         env: PYTHON_VERSION=3.7
 
 install:
+  - pip3 install -U pip
   - pip3 install -r requirements.txt
   - python3 -m nltk.downloader punkt
   - python3 -m nltk.downloader wordnet

--- a/matchzoo/layers/dynamic_pooling_layer.py
+++ b/matchzoo/layers/dynamic_pooling_layer.py
@@ -74,9 +74,9 @@ class DynamicPoolingLayer(Layer):
                                      suggestion1, suggestion2))
 
         x_pool = tf.nn.max_pool(x_expand,
-                                  [1, stride1, stride2, 1],
-                                  [1, stride1, stride2, 1],
-                                  "VALID")
+                                [1, stride1, stride2, 1],
+                                [1, stride1, stride2, 1],
+                                "VALID")
         return x_pool
 
     def compute_output_shape(self, input_shape: list) -> tuple:

--- a/matchzoo/layers/dynamic_pooling_layer.py
+++ b/matchzoo/layers/dynamic_pooling_layer.py
@@ -1,7 +1,7 @@
 """An implementation of Dynamic Pooling Layer."""
 import typing
 
-from keras import backend as K
+import tensorflow as tf
 from keras.engine import Layer
 
 
@@ -50,16 +50,16 @@ class DynamicPoolingLayer(Layer):
         :param inputs: two input tensors.
         """
         x, dpool_index = inputs
-        dpool_shape = K.tf.shape(dpool_index)
-        batch_index_one = K.tf.expand_dims(
-            K.tf.expand_dims(
-                K.tf.range(dpool_shape[0]), axis=-1),
+        dpool_shape = tf.shape(dpool_index)
+        batch_index_one = tf.expand_dims(
+            tf.expand_dims(
+                tf.range(dpool_shape[0]), axis=-1),
             axis=-1)
-        batch_index = K.tf.expand_dims(
-            K.tf.tile(batch_index_one, [1, self._msize1, self._msize2]),
+        batch_index = tf.expand_dims(
+            tf.tile(batch_index_one, [1, self._msize1, self._msize2]),
             axis=-1)
-        dpool_index_ex = K.tf.concat([batch_index, dpool_index], axis=3)
-        x_expand = K.tf.gather_nd(x, dpool_index_ex)
+        dpool_index_ex = tf.concat([batch_index, dpool_index], axis=3)
+        x_expand = tf.gather_nd(x, dpool_index_ex)
         stride1 = self._msize1 / self._psize1
         stride2 = self._msize2 / self._psize2
 
@@ -73,7 +73,7 @@ class DynamicPoolingLayer(Layer):
                              .format(self._psize1, self._psize2,
                                      suggestion1, suggestion2))
 
-        x_pool = K.tf.nn.max_pool(x_expand,
+        x_pool = tf.nn.max_pool(x_expand,
                                   [1, stride1, stride2, 1],
                                   [1, stride1, stride2, 1],
                                   "VALID")

--- a/matchzoo/layers/matching_layer.py
+++ b/matchzoo/layers/matching_layer.py
@@ -1,6 +1,7 @@
 """An implementation of Matching Layer."""
 import typing
 
+import tensorflow as tf
 from keras import backend as K
 from keras.engine import Layer
 
@@ -76,7 +77,7 @@ class MatchingLayer(Layer):
             if self._normalize:
                 x1 = K.l2_normalize(x1, axis=2)
                 x2 = K.l2_normalize(x2, axis=2)
-            return K.tf.expand_dims(K.tf.einsum('abd,acd->abc', x1, x2), 3)
+            return K.expand_dims(tf.einsum('abd,acd->abc', x1, x2), 3)
         else:
             if self._matching_type == 'mul':
                 def func(x, y):
@@ -89,14 +90,14 @@ class MatchingLayer(Layer):
                     return x - y
             elif self._matching_type == 'concat':
                 def func(x, y):
-                    return K.tf.concat([x, y], axis=3)
+                    return tf.concat([x, y], axis=3)
             else:
                 raise ValueError(f"Invalid matching type."
                                  f"{self._matching_type} received."
                                  f"Mut be in `dot`, `mul`, `plus`, "
                                  f"`minus` and `concat`.")
-            x1_exp = K.tf.stack([x1] * self._shape2[1], 2)
-            x2_exp = K.tf.stack([x2] * self._shape1[1], 1)
+            x1_exp = K.stack([x1] * self._shape2[1], 2)
+            x2_exp = K.stack([x2] * self._shape1[1], 1)
             return func(x1_exp, x2_exp)
 
     def compute_output_shape(self, input_shape: list) -> tuple:

--- a/matchzoo/losses/rank_cross_entropy_loss.py
+++ b/matchzoo/losses/rank_cross_entropy_loss.py
@@ -5,6 +5,7 @@ import numpy as np
 from keras.losses import Loss
 from keras.utils import losses_utils
 
+
 class RankCrossEntropyLoss(Loss):
     """
     Rank cross entropy loss.
@@ -27,10 +28,12 @@ class RankCrossEntropyLoss(Loss):
 
         :param num_neg: number of negative instances in cross entropy loss.
         """
-        super().__init__(reduction=losses_utils.Reduction.SUM_OVER_BATCH_SIZE, name="rank_crossentropy")
+        super().__init__(reduction=losses_utils.Reduction.SUM_OVER_BATCH_SIZE,
+                         name="rank_crossentropy")
         self._num_neg = num_neg
 
-    def call(self, y_true: np.array, y_pred: np.array,  sample_weight=None) -> np.array:
+    def call(self, y_true: np.array, y_pred: np.array,
+             sample_weight=None) -> np.array:
         """
         Calculate rank cross entropy loss.
 

--- a/matchzoo/losses/rank_hinge_loss.py
+++ b/matchzoo/losses/rank_hinge_loss.py
@@ -30,12 +30,14 @@ class RankHingeLoss(Loss):
         :param num_neg: number of negative instances in hinge loss.
         :param margin: the margin between positive and negative scores.
         """
-        super().__init__(reduction=losses_utils.Reduction.SUM_OVER_BATCH_SIZE, name="rank_hinge")
+        super().__init__(reduction=losses_utils.Reduction.SUM_OVER_BATCH_SIZE,
+                         name="rank_hinge")
 
         self._num_neg = num_neg
         self._margin = margin
 
-    def call(self, y_true: np.array, y_pred: np.array, sample_weight=None) -> np.array:
+    def call(self, y_true: np.array, y_pred: np.array,
+             sample_weight=None) -> np.array:
         """
         Calculate rank hinge loss.
 

--- a/matchzoo/models/conv_knrm.py
+++ b/matchzoo/models/conv_knrm.py
@@ -2,11 +2,10 @@
 
 import keras
 import keras.backend as K
+import tensorflow as tf
 
 from .knrm import KNRM
 from matchzoo.engine.param import Param
-from matchzoo.engine.param_table import ParamTable
-from matchzoo.engine import hyper_spaces
 
 
 class ConvKNRM(KNRM):
@@ -87,13 +86,13 @@ class ConvKNRM(KNRM):
                         mu = 1.0
                     mm_exp = self._kernel_layer(mu, sigma)(mm)
                     mm_doc_sum = keras.layers.Lambda(
-                        lambda x: K.tf.reduce_sum(x, 2))(
+                        lambda x: K.sum(x, 2))(
                         mm_exp)
-                    mm_log = keras.layers.Activation(K.tf.log1p)(mm_doc_sum)
+                    mm_log = keras.layers.Activation(tf.math.log1p)(mm_doc_sum)
                     mm_sum = keras.layers.Lambda(
-                        lambda x: K.tf.reduce_sum(x, 1))(mm_log)
+                        lambda x: K.sum(x, 1))(mm_log)
                     KM.append(mm_sum)
 
-        phi = keras.layers.Lambda(lambda x: K.tf.stack(x, 1))(KM)
+        phi = keras.layers.Lambda(lambda x: K.stack(x, 1))(KM)
         out = self._make_output_layer()(phi)
         self._backend = keras.Model(inputs=[query, doc], outputs=[out])

--- a/matchzoo/models/drmm.py
+++ b/matchzoo/models/drmm.py
@@ -114,7 +114,7 @@ class DRMM(BaseModel):
             )(dense_input)
         # shape = [B, L, 1]
         attention_probs = keras.layers.Lambda(
-            lambda x: keras.layers.activations.softmax(x, axis=1),
+            lambda x: keras.activations.softmax(x, axis=1),
             output_shape=lambda s: (s[0], s[1], s[2]),
             name="attention_probs"
         )(dense_input)

--- a/matchzoo/models/drmmtks.py
+++ b/matchzoo/models/drmmtks.py
@@ -2,7 +2,7 @@
 import typing
 
 import keras
-import keras.backend as K
+import tensorflow as tf
 
 from matchzoo.engine.base_model import BaseModel
 from matchzoo.engine.param import Param
@@ -67,11 +67,11 @@ class DRMMTKS(BaseModel):
         # shape = [B, R, D]
         embed_doc = embedding(doc)
         # shape = [B, L]
-        atten_mask = K.not_equal(query, self._params['mask_value'])
+        atten_mask = tf.not_equal(query, self._params['mask_value'])
         # shape = [B, L]
-        atten_mask = K.cast(atten_mask, K.floatx())
+        atten_mask = tf.cast(atten_mask, keras.backend.floatx())
         # shape = [B, L, 1]
-        atten_mask = K.expand_dims(atten_mask, axis=2)
+        atten_mask = tf.expand_dims(atten_mask, axis=2)
         # shape = [B, L, 1]
         attention_probs = self.attention_layer(embed_query, atten_mask)
 
@@ -85,7 +85,7 @@ class DRMMTKS(BaseModel):
                               self.params['input_shapes'][0][0],
                               self.params['input_shapes'][1][0])
         matching_topk = keras.layers.Lambda(
-            lambda x: K.tf.nn.top_k(x, k=effective_top_k, sorted=True)[0]
+            lambda x: tf.nn.top_k(x, k=effective_top_k, sorted=True)[0]
         )(matching_matrix)
 
         # Process right input.
@@ -127,7 +127,7 @@ class DRMMTKS(BaseModel):
             )(dense_input)
         # shape = [B, L, 1]
         attention_probs = keras.layers.Lambda(
-            lambda x: keras.layers.activations.softmax(x, axis=1),
+            lambda x: keras.activations.softmax(x, axis=1),
             output_shape=lambda s: (s[0], s[1], s[2]),
             name="attention_probs"
         )(dense_input)

--- a/matchzoo/models/duet.py
+++ b/matchzoo/models/duet.py
@@ -149,10 +149,10 @@ class DUET(BaseModel):
         t2 = x[1]
         t1_shape = t1.get_shape()
         t2_shape = t2.get_shape()
-        t1_expand = K.tf.stack([t1] * t2_shape[1], 2)
-        t2_expand = K.tf.stack([t2] * t1_shape[1], 1)
-        out_bool = K.tf.equal(t1_expand, t2_expand)
-        out = K.tf.cast(out_bool, K.tf.float32)
+        t1_expand = tf.stack([t1] * t2_shape[1], 2)
+        t2_expand = tf.stack([t2] * t1_shape[1], 1)
+        out_bool = tf.equal(t1_expand, t2_expand)
+        out = tf.cast(out_bool, tf.float32)
         return out
 
     @classmethod

--- a/matchzoo/models/knrm.py
+++ b/matchzoo/models/knrm.py
@@ -1,6 +1,7 @@
 """KNRM model."""
 import keras
 import keras.backend as K
+import tensorflow as tf
 
 from matchzoo.engine.base_model import BaseModel
 from matchzoo.engine.param import Param
@@ -69,13 +70,13 @@ class KNRM(BaseModel):
                 mu = 1.0
             mm_exp = self._kernel_layer(mu, sigma)(mm)
             mm_doc_sum = keras.layers.Lambda(
-                lambda x: K.tf.reduce_sum(x, 2))(mm_exp)
-            mm_log = keras.layers.Activation(K.tf.log1p)(mm_doc_sum)
+                lambda x: K.sum(x, 2))(mm_exp)
+            mm_log = keras.layers.Activation(tf.math.log1p)(mm_doc_sum)
             mm_sum = keras.layers.Lambda(
-                lambda x: K.tf.reduce_sum(x, 1))(mm_log)
+                lambda x: K.sum(x, 1))(mm_log)
             KM.append(mm_sum)
 
-        phi = keras.layers.Lambda(lambda x: K.tf.stack(x, 1))(KM)
+        phi = keras.layers.Lambda(lambda x: K.stack(x, 1))(KM)
         out = self._make_output_layer()(phi)
         self._backend = keras.Model(inputs=[query, doc], outputs=[out])
 
@@ -90,6 +91,6 @@ class KNRM(BaseModel):
         """
 
         def kernel(x):
-            return K.tf.exp(-0.5 * (x - mu) * (x - mu) / sigma / sigma)
+            return K.exp(-0.5 * (x - mu) * (x - mu) / sigma / sigma)
 
         return keras.layers.Activation(kernel)

--- a/matchzoo/models/mvlstm.py
+++ b/matchzoo/models/mvlstm.py
@@ -2,7 +2,7 @@
 import typing
 
 import keras
-import keras.backend as K
+import tensorflow as tf
 
 import matchzoo
 from matchzoo.engine.base_model import BaseModel
@@ -73,7 +73,7 @@ class MVLSTM(BaseModel):
             axes=[2, 2], normalize=False)([rep_query, rep_doc])
         matching_signals = keras.layers.Reshape((-1,))(matching_matrix)
         matching_topk = keras.layers.Lambda(
-            lambda x: K.tf.nn.top_k(x, k=self._params['top_k'], sorted=True)[0]
+            lambda x: tf.nn.top_k(x, k=self._params['top_k'], sorted=True)[0]
         )(matching_signals)
 
         # Multilayer perceptron layer.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-keras == 2.2.4
+keras == 2.3.0
 tabulate >= 0.8.2
-tensorflow >= 1.1.0
+tensorflow >= 2.0.0
 nltk >= 3.2.3
 numpy >= 1.14
 tqdm >= 4.19.4


### PR DESCRIPTION
* make losses inherit `keras.losses.Loss`
* replace some `keras.backend.tf` with `tf` (K.tf does not exist anymore as keras is going to be synced with tf.keras and drop multi-backend)

We may consider to replace `keras` with `tf.keras` in the future.

fix #789 