### PR TITLE
w2v embedding loading function modified

### DIFF
--- a/matchzoo/embedding/embedding.py
+++ b/matchzoo/embedding/embedding.py
@@ -98,7 +98,8 @@ def load_from_file(file_path: str, mode: str = 'word2vec') -> Embedding:
                            sep=" ",
                            index_col=0,
                            header=None,
-                           skiprows=1)
+                           skiprows=1,
+                           quoting=csv.QUOTE_NONE)
     elif mode == 'glove':
         data = pd.read_csv(file_path,
                            sep=" ",


### PR DESCRIPTION
Add a parameter in loading function, in order to solve the w2v embedding loading memory [issue](https://github.com/NTMC-Community/MatchZoo/issues/807).
