### PR TITLE
Fix tqdm version for CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ tabulate >= 0.8.2
 tensorflow >= 2.0.0
 nltk >= 3.2.3
 numpy >= 1.14
-tqdm >= 4.23.4
+tqdm == 4.23.4
 dill >= 0.2.7.1
 hyperopt >= 0.1.1
 pandas == 0.24.2


### PR DESCRIPTION
The latest `tqdm.pandas()` has some problems.

Notebook: https://gist.github.com/matthew-z/1e90517b34ed0ad67a47e9ad5a9b94e0